### PR TITLE
PSDK-874: Be more explicit in which controls are shown for each ad player event

### DIFF
--- a/base/package.json
+++ b/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html5-adplayer-skin",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "private": true,
   "dependencies": {
     "grunt": "*",


### PR DESCRIPTION
For each event which updates the UI, hide all controls by default, and then show the ones explicitly named