### PR TITLE
"except" option is deprecated in "grunt-contrib-uglify" latest package, use "reserved" instead.

### DIFF
--- a/base/Gruntfile.js
+++ b/base/Gruntfile.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
             skin: {
                 options: {
                     mangle: {
-                        except: ['error', 'format', 'request', 'model', 'parse', 'core', 'window', 'document', 'console']
+                        reserved: ['error', 'format', 'request', 'model', 'parse', 'core', 'window', 'document', 'console']
                     }
                 },
                 files: {


### PR DESCRIPTION
"except" option is deprecated in "grunt-contrib-uglify" latest package, use "reserved" instead.